### PR TITLE
fix 2019-10 crates.io typo

### DIFF
--- a/2019/2019-10.md
+++ b/2019/2019-10.md
@@ -44,7 +44,7 @@ _by mafintosh_
 ## Publishing the Cargo registry on Dat
 _by Agent of User_
 
-[Agent of User](https://github.com/agentofuser) has been experimenting with mirroring Rust crates (modules) from [creates.io](https://viewer.scuttlebot.io/%25M8DEDuxZZhg7Ly4VVJnE3Az1N7tSCWw5v2AuO2ay3h8%3D.sha256) (kinda like Rust's NPM) through Dat and IPFS. You can help the effort by seeding the dat archive, or contributing to the effort. dat://91067272f618b28f22c02a6f95089e9ffbf120016d8f1023ad74575bd03d77ca
+[Agent of User](https://github.com/agentofuser) has been experimenting with mirroring Rust crates (modules) from [crates.io](https://viewer.scuttlebot.io/%25M8DEDuxZZhg7Ly4VVJnE3Az1N7tSCWw5v2AuO2ay3h8%3D.sha256) (kinda like Rust's NPM) through Dat and IPFS. You can help the effort by seeding the dat archive, or contributing to the effort. dat://91067272f618b28f22c02a6f95089e9ffbf120016d8f1023ad74575bd03d77ca
 
 [READ MORE](https://viewer.scuttlebot.io/%25M8DEDuxZZhg7Ly4VVJnE3Az1N7tSCWw5v2AuO2ay3h8%3D.sha256)
 


### PR DESCRIPTION
just a small typo: `creates.io` vs. `crates.io`.